### PR TITLE
fix for yaml swallowing quotes

### DIFF
--- a/src/main/python/ultimate_source_of_accounts/account_converter.py
+++ b/src/main/python/ultimate_source_of_accounts/account_converter.py
@@ -10,6 +10,19 @@ import logging
 FILENAME = "accounts"
 
 
+def represent_unicode(dumper, data, style=None):
+    if not dumper.default_style and data.isdigit():
+        style = "'"
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data, style=style)
+
+
+class MyDumper(yaml.Dumper):
+    pass
+
+# Always use quotes when the string contains only digits
+MyDumper.add_representer(str, represent_unicode)
+
+
 def get_converted_aws_accounts(accounts):
     """Return converted AWS account data.
 
@@ -17,7 +30,8 @@ def get_converted_aws_accounts(accounts):
     uploading to S3, these become "S3 key" -> "S3 value" pairs.
     """
     try:
-        yaml_data = yaml.dump(accounts, indent=2, default_flow_style=False)
+        yaml_data = yaml.dump(accounts, indent=2, default_flow_style=False,
+                              Dumper=MyDumper)
         json_data = json.dumps(accounts, sort_keys=True, indent=2)
     except Exception as exc:
         raise Exception("Failed to convert to yaml and json: {0}".format(exc))


### PR DESCRIPTION
We recent encountered some yaml issues. Imagine a yaml file contains an account
number like 012345678. Since it 'seems' to be a number we might expect it to be
quoted in the final yaml output. However, two things cause this to not happen:

a) The number starts with a leading '0' which is interpreted by Python as
   octal.

b) Actually, it can not be octal since it contains the digit '8' and so yaml
   says that it must be string and discards the quoting because it is not
   ambiguous.

This means that in the final accounts.yaml most accounts are quote except for
those that start with a leading '0' and contain either and '8' or a '9'.

This is an adapted fix inspired by the comments in:

https://bitbucket.org/xi/pyyaml/issues/29/zero-padded-numbers-ending-in-8-or-9-dump
